### PR TITLE
Add gulp-dart-sass support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,6 +33,7 @@ Almost all colors in the logs are configurable.
 * [gulp-stylus](https://www.npmjs.com/package/gulp-stylus)
 * [gulp-less](https://www.npmjs.com/package/gulp-less)
 * [gulp-sass](https://www.npmjs.com/package/gulp-sass)
+* [gulp-dart-sass](https://www.npmjs.com/package/gulp-dart-sass)
 * [gulp-postcss](https://www.npmjs.com/package/gulp-postcss)
 
 Even for those errors that are not supported,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wulechuan/printer-for-errors-of-gulp-plugins",
-  "version": "1.0.0",
+  "name": "@ronilaukkarinen/printer-for-errors-of-gulp-plugins",
+  "version": "1.0.1",
   "author": "wulechuan <wulechuan@live.com>",
   "license": "WTFPL",
   "description": "Parse and print PluginError objects of gulpjs, beautifully.",

--- a/source/gulp-plugin-error-parsers/gulp-dart-sass-error-parser.js
+++ b/source/gulp-plugin-error-parsers/gulp-dart-sass-error-parser.js
@@ -1,0 +1,60 @@
+module.exports = function parseGulpSassPluginError(error) {
+	if (typeof error !== 'object') {
+		return null;
+	}
+
+	const shouldPrintErrorObjectForDebugging = false;
+	if (shouldPrintErrorObjectForDebugging) {
+		require('../utils/print-javascript-object')(error);
+		return;
+	}
+
+	const {
+		status:          sassErrorStatusNumber,
+		messageOriginal: conclusionMessage,
+		message,         // for gulp-dart-sass, this property is only used for asserting the error to a valid one
+		formatted:       messageThatContainsInvolvedSnippet,
+		name:            errorRawType,
+		file:            stackTopItemFilePath, // also available as fileName (camel case).
+		line:            stackTopItemLineNumber,
+		column:          stackTopItemColumnNumber,
+	} = error;
+
+	if (! message) {
+		return null;
+	}
+
+	if (! stackTopItemFilePath) {
+		return null;
+	}
+
+
+
+	let involvedErrorLine;
+	// let sassErrorDecorationLine;
+	// let errorDecorationLine;
+
+	const matchingResult1 =  messageThatContainsInvolvedSnippet.match(/ss\n>> ([^\n]+)\n/);
+	if (matchingResult1) {
+		[ , involvedErrorLine ] = matchingResult1;
+	}
+
+	const involvedSnippet = [ involvedErrorLine ];
+
+	return {
+		errorType: `${errorRawType}(${sassErrorStatusNumber})`,
+
+		stackTopItem: {
+			path:                                  stackTopItemFilePath,
+			lineNumber:                            stackTopItemLineNumber,
+			columnNumber:                          stackTopItemColumnNumber,
+			involvedSnippet,
+
+			involvedSnippetKeyLineIndexInTheArray: 0,
+
+			conclusionMessage,
+		},
+
+		deeperStacks: null,
+	};
+};

--- a/source/gulp-plugin-error-printer.js
+++ b/source/gulp-plugin-error-printer.js
@@ -67,6 +67,8 @@ function choosePluginErrorParseAccordingToInvolvedPluginName(pluginName) {
 			return require('./gulp-plugin-error-parsers/gulp-less-error-parser');
 		case 'gulp-sass':
 			return require('./gulp-plugin-error-parsers/gulp-sass-error-parser');
+		case 'gulp-dart-sass':
+			return require('./gulp-plugin-error-parsers/gulp-dart-sass-error-parser');
 		case 'gulp-postcss':
 			return require('./gulp-plugin-error-parsers/gulp-postcss-error-parser');
 		default:


### PR DESCRIPTION
Hello! Gulp-dart-sass supports almost same configuration with gulp-sass. I think it's good to have supported as it's newer. This PR adds support to it. Can you please merge the change, thanks!